### PR TITLE
DelegateCraftingInventory: Minor optimizations + Implement missing overrides

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.5-SNAPSHOT'
+    id 'fabric-loom' version '1.6-SNAPSHOT'
     id 'me.modmuss50.mod-publish-plugin' version '0.4.5'
     id 'maven-publish'
 }

--- a/src/main/java/me/luligabi/enhancedworkbenches/common/screenhandler/CraftingBlockScreenHandler.java
+++ b/src/main/java/me/luligabi/enhancedworkbenches/common/screenhandler/CraftingBlockScreenHandler.java
@@ -74,10 +74,6 @@ public abstract class CraftingBlockScreenHandler extends ScreenHandler {
         return canUse(context, player, getBlock());
     }
 
-    public void provideRecipeInputs(RecipeMatcher matcher) {
-        input.provideRecipeInputs(matcher);
-    }
-
 
     protected abstract Block getBlock();
 

--- a/src/main/java/me/luligabi/enhancedworkbenches/common/screenhandler/DelegateCraftingInventory.java
+++ b/src/main/java/me/luligabi/enhancedworkbenches/common/screenhandler/DelegateCraftingInventory.java
@@ -4,7 +4,11 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.RecipeMatcher;
 import net.minecraft.screen.ScreenHandler;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class DelegateCraftingInventory extends CraftingInventory {
 
@@ -72,6 +76,22 @@ public class DelegateCraftingInventory extends CraftingInventory {
     public void clear() {
         for(int i = 0; i < 9; i++) {
             removeStack(i);
+        }
+    }
+
+    @Override
+    public List<ItemStack> getInputStacks() {
+        List<ItemStack> stacks = new ArrayList<>(9);
+        for(int i = 0; i < 9; i++) {
+            stacks.add(getStack(i));
+        }
+        return stacks;
+    }
+
+    @Override
+    public void provideRecipeInputs(RecipeMatcher finder) {
+        for(int i = 0; i < 9; i++) {
+            finder.addUnenchantedInput(getStack(i));
         }
     }
 }

--- a/src/main/java/me/luligabi/enhancedworkbenches/common/screenhandler/DelegateCraftingInventory.java
+++ b/src/main/java/me/luligabi/enhancedworkbenches/common/screenhandler/DelegateCraftingInventory.java
@@ -24,7 +24,7 @@ public class DelegateCraftingInventory extends CraftingInventory {
 
     @Override
     public boolean isEmpty() {
-        for(int i = 0; i < size(); i++) {
+        for(int i = 0; i < 9; i++) {
             if(!getStack(i).isEmpty()) return false;
         }
         return true;
@@ -32,7 +32,7 @@ public class DelegateCraftingInventory extends CraftingInventory {
 
     @Override
     public ItemStack getStack(int slot) {
-        return slot >= size() ? ItemStack.EMPTY : input.getStack(slot);
+        return slot >= 9 ? ItemStack.EMPTY : input.getStack(slot);
     }
 
     @Override
@@ -70,7 +70,7 @@ public class DelegateCraftingInventory extends CraftingInventory {
 
     @Override
     public void clear() {
-        for(int i = 0; i < size(); i++) {
+        for(int i = 0; i < 9; i++) {
             removeStack(i);
         }
     }


### PR DESCRIPTION
This PR makes minor optimizations to `DelegateCraftingInventory` (replacing `size()` calls with a constant `9`) and implements missing overrides from `CraftingInventory`, which should fix Crafting Tweaks integration (which was non-functional).