### PR TITLE
Take items from Project Table inventory while crafting

### DIFF
--- a/common/src/main/java/me/luligabi/enhancedworkbenches/common/common/menu/CraftingBlockMenu.java
+++ b/common/src/main/java/me/luligabi/enhancedworkbenches/common/common/menu/CraftingBlockMenu.java
@@ -106,9 +106,15 @@ public abstract class CraftingBlockMenu extends AbstractContainerMenu {
     }
 
     protected class CraftingOutputSlot extends ResultSlot {
+        protected Container craftingInventoryRef = null;
 
         public CraftingOutputSlot(Player player, int index, int x, int y) {
             super(player, CraftingBlockMenu.this.input, CraftingBlockMenu.this.result, index, x, y);
+        }
+
+        public CraftingOutputSlot(Player player, Container craftingInventory, int index, int x, int y) {
+            this(player, index, x, y);
+            this.craftingInventoryRef = craftingInventory;
         }
 
         @Override
@@ -137,9 +143,31 @@ public abstract class CraftingBlockMenu extends AbstractContainerMenu {
 
         @Override
         public void onTake(Player player, ItemStack stack) {
+            tryRefillFromInventory();
             super.onTake(player, stack);
             setChanged();
         }
 
+        protected void tryRefillFromInventory() {
+            if (craftingInventoryRef == null) {
+                return;
+            }
+
+            var craftSlots = CraftingBlockMenu.this.input;
+
+            for (int i = 0; i < craftSlots.getContainerSize(); i++) {
+                ItemStack stack = craftSlots.getItem(i);
+                if (!stack.isEmpty()) {
+                    for (int j = 0; j < craftingInventoryRef.getContainerSize(); j++) {
+                        ItemStack inventoryStack = craftingInventoryRef.getItem(j);
+                        if (inventoryStack.getItem() == stack.getItem() && inventoryStack.getCount() > 0) {
+                            inventoryStack.setCount(inventoryStack.getCount() - 1);
+                            stack.setCount(stack.getCount() + 1);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/common/src/main/java/me/luligabi/enhancedworkbenches/common/common/menu/ProjectTableMenu.java
+++ b/common/src/main/java/me/luligabi/enhancedworkbenches/common/common/menu/ProjectTableMenu.java
@@ -23,7 +23,7 @@ public class ProjectTableMenu extends CraftingBlockMenu {
         checkContainerSize(inventory, 18);
         inventory.startOpen(player);
 
-        addSlot(new CraftingOutputSlot(player, 0, 124, 35));
+        addSlot(new CraftingOutputSlot(player, inventory, 0, 124, 35));
 
         for(int i = 0; i < 3; ++i) {
             for(int j = 0; j < 3; ++j) {


### PR DESCRIPTION
This PR reintroduces a feature inspired by the old RedPower Project Bench: automatically pulling items from the internal inventory to refill crafting slots. This enables continuous crafting, even if some materials run out.

I’ve aimed for a faithful recreation, but feel free to adjust the implementation to better fit your codebase.